### PR TITLE
refactor: use score-helm in cmd directory

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,7 +5,7 @@ before:
 builds:
   - id: score-helm
     binary: score-helm
-    main: ./cli
+    main: ./cmd/score-helm
     ldflags:
       - -X github.com/score-spec/score-helm/internal/version.Version={{ .Version }}
       - -X github.com/score-spec/score-helm/internal/version.BuildTime={{ .CommitDate }}

--- a/cmd/score-helm/main.go
+++ b/cmd/score-helm/main.go
@@ -11,12 +11,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/score-spec/score-helm/cli/cmd"
+	"github.com/score-spec/score-helm/internal/command"
 )
 
 func main() {
 
-	if err := cmd.Execute(); err != nil {
+	if err := command.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -5,7 +5,7 @@ Copyright 2020 The Apache Software Foundation
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 */
-package cmd
+package command
 
 import (
 	"fmt"

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -5,7 +5,7 @@ Copyright 2020 The Apache Software Foundation
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 */
-package cmd
+package command
 
 import (
 	"fmt"


### PR DESCRIPTION
Signed-off-by: rachfop <prachford@icloud.com>

<!--- Provide a general summary of your changes in the Title above -->

Description

Rename cli to cmd/score-compose
What does this PR do?

With current package management, the final cli name is cli, not score-compose.
This PR changes the package name, users can install by go install github.com/score-spec/score-helm/cmd/score-helm@latest to get the score-helm cli in $GOBIN


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I've signed off with an email address that matches the commit author.
