### PR TITLE
feat: upgraded score-go to 1.1.0 and supressed double error printing

### DIFF
--- a/cmd/score-helm/main.go
+++ b/cmd/score-helm/main.go
@@ -17,7 +17,7 @@ import (
 func main() {
 
 	if err := command.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		_, _ = fmt.Fprintln(os.Stderr, "Error: "+err.Error())
 		os.Exit(1)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,13 @@
 module github.com/score-spec/score-helm
 
-go 1.19
+go 1.22
+
+toolchain go1.22.0
 
 require (
 	github.com/imdario/mergo v0.3.13
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/score-spec/score-go v0.0.0-20230905115428-131acdd2f5cf
+	github.com/score-spec/score-go v1.1.0
 	github.com/spf13/cobra v1.6.0
 	github.com/stretchr/testify v1.8.0
 	github.com/tidwall/sjson v1.2.5

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
-github.com/score-spec/score-go v0.0.0-20230905115428-131acdd2f5cf h1:0Dt+qyYoGTXPPU5Xq/KxLDtQMMA8hX+oJ8EsjFWUajQ=
-github.com/score-spec/score-go v0.0.0-20230905115428-131acdd2f5cf/go.mod h1:3l9mvrtYKzxXDQVcYkQBD3ABTPkTzWhUMYNfGlpctoo=
+github.com/score-spec/score-go v1.1.0 h1:63WM1u93NtGgMuPtVZ/UBfzg/BpYuY8sBquaL0BkrXU=
+github.com/score-spec/score-go v1.1.0/go.mod h1:nt6TOq2Ld9SiH3Fd9NF8tiJ9L7S17OE3FNgCrSet5GQ=
 github.com/spf13/cobra v1.6.0 h1:42a0n6jwCot1pUmomAp4T7DeMD+20LFv4Q54pxLf2LI=
 github.com/spf13/cobra v1.6.0/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -10,8 +10,9 @@ package command
 import (
 	"fmt"
 
-	"github.com/score-spec/score-helm/internal/version"
 	"github.com/spf13/cobra"
+
+	"github.com/score-spec/score-helm/internal/version"
 )
 
 var (
@@ -21,7 +22,8 @@ var (
 		Long: `SCORE is a specification for defining environment agnostic configuration for cloud based workloads.
 This tool produces a Helm chart from the SCORE specification.
 Complete documentation is available at https://score.dev.`,
-		Version: fmt.Sprintf("%s (build: %s; sha: %s)", version.Version, version.BuildTime, version.GitSHA),
+		Version:       fmt.Sprintf("%s (build: %s; sha: %s)", version.Version, version.BuildTime, version.GitSHA),
+		SilenceErrors: true,
 	}
 )
 

--- a/internal/helm/convert_test.go
+++ b/internal/helm/convert_test.go
@@ -17,7 +17,7 @@ import (
 func TestScoreConvert(t *testing.T) {
 	var tests = []struct {
 		Name     string
-		Spec     *score.WorkloadSpec
+		Spec     *score.Workload
 		Values   map[string]interface{}
 		Expected map[string]interface{}
 		Error    error
@@ -26,24 +26,24 @@ func TestScoreConvert(t *testing.T) {
 		//
 		{
 			Name: "Should convert SCORE to Helm values",
-			Spec: &score.WorkloadSpec{
-				Metadata: score.WorkloadMeta{
-					Name: "test",
+			Spec: &score.Workload{
+				Metadata: score.WorkloadMetadata{
+					"name": "test",
 				},
-				Service: score.ServiceSpec{
-					Ports: score.ServicePortsSpecs{
-						"www": score.ServicePortSpec{
+				Service: &score.WorkloadService{
+					Ports: score.WorkloadServicePorts{
+						"www": score.ServicePort{
 							Port:       80,
-							TargetPort: 8080,
+							TargetPort: Ref(8080),
 						},
-						"admin": score.ServicePortSpec{
+						"admin": score.ServicePort{
 							Port:     8080,
-							Protocol: "UDP",
+							Protocol: Ref(score.ServicePortProtocolUDP),
 						},
 					},
 				},
-				Containers: score.ContainersSpecs{
-					"backend": score.ContainerSpec{
+				Containers: score.WorkloadContainers{
+					"backend": score.Container{
 						Image: "busybox",
 						Command: []string{
 							"/bin/sh",
@@ -97,12 +97,12 @@ func TestScoreConvert(t *testing.T) {
 		},
 		{
 			Name: "Should convert all resources references",
-			Spec: &score.WorkloadSpec{
-				Metadata: score.WorkloadMeta{
-					Name: "test",
+			Spec: &score.Workload{
+				Metadata: score.WorkloadMetadata{
+					"name": "test",
 				},
-				Containers: score.ContainersSpecs{
-					"backend": score.ContainerSpec{
+				Containers: score.WorkloadContainers{
+					"backend": score.Container{
 						Image: "busybox",
 						Variables: map[string]string{
 							"DEBUG":             "${resources.env.DEBUG}",
@@ -110,17 +110,17 @@ func TestScoreConvert(t *testing.T) {
 							"DOMAIN_NAME":       "${resources.dns.domain_name}",
 							"CONNECTION_STRING": "postgresql://${resources.app-db.host}:${resources.app-db.port}/${resources.app-db.name}",
 						},
-						Volumes: []score.VolumeMountSpec{
+						Volumes: []score.ContainerVolumesElem{
 							{
 								Source:   "${resources.data}",
-								Path:     "sub/path",
+								Path:     Ref("sub/path"),
 								Target:   "/mnt/data",
-								ReadOnly: true,
+								ReadOnly: Ref(true),
 							},
 						},
 					},
 				},
-				Resources: map[string]score.ResourceSpec{
+				Resources: score.WorkloadResources{
 					"env": {
 						Type: "environment",
 					},

--- a/internal/helm/ref.go
+++ b/internal/helm/ref.go
@@ -1,0 +1,5 @@
+package helm
+
+func Ref[k any](input k) *k {
+	return &input
+}

--- a/internal/helm/templates.go
+++ b/internal/helm/templates.go
@@ -25,12 +25,12 @@ var (
 // templatesContext ia an utility type that provides a context for '${...}' templates substitution
 type templatesContext struct {
 	meta      map[string]interface{}
-	resources score.ResourcesSpecs
+	resources score.WorkloadResources
 	values    map[string]interface{}
 }
 
 // buildContext initializes a new templatesContext instance
-func buildContext(metadata score.WorkloadMeta, resources score.ResourcesSpecs, values map[string]interface{}) (*templatesContext, error) {
+func buildContext(metadata score.WorkloadMetadata, resources score.WorkloadResources, values map[string]interface{}) (*templatesContext, error) {
 	var metadataMap = make(map[string]interface{})
 	if decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		TagName: "json",

--- a/internal/helm/templates_test.go
+++ b/internal/helm/templates_test.go
@@ -15,18 +15,18 @@ import (
 )
 
 func TestMapVar(t *testing.T) {
-	var meta = score.WorkloadMeta{
-		Name: "test-name",
+	var meta = score.WorkloadMetadata{
+		"name": "test-name",
 	}
 
-	var resources = score.ResourcesSpecs{
-		"env": score.ResourceSpec{
+	var resources = score.WorkloadResources{
+		"env": score.Resource{
 			Type: "environment",
 		},
-		"db": score.ResourceSpec{
+		"db": score.Resource{
 			Type: "postgres",
 		},
-		"dns": score.ResourceSpec{
+		"dns": score.Resource{
 			Type: "dns",
 		},
 	}
@@ -64,18 +64,18 @@ func TestMapVar(t *testing.T) {
 }
 
 func TestSubstitute(t *testing.T) {
-	var meta = score.WorkloadMeta{
-		Name: "test-name",
+	var meta = score.WorkloadMetadata{
+		"name": "test-name",
 	}
 
-	var resources = score.ResourcesSpecs{
-		"env": score.ResourceSpec{
+	var resources = score.WorkloadResources{
+		"env": score.Resource{
 			Type: "environment",
 		},
-		"db": score.ResourceSpec{
+		"db": score.Resource{
 			Type: "postgres",
 		},
-		"dns": score.ResourceSpec{
+		"dns": score.Resource{
 			Type: "dns",
 		},
 	}


### PR DESCRIPTION
Like the similar PR's submitted to score-compose and others, this PR updates the version of score-go (and thus the embedded score spec). This adds tighter and more useful validation and error messages and ensures that score-helm meets the score spec and expected behavior.

(We also update the version of Go being used).

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] I've signed off with an email address that matches the commit author.

#### Demo

When run against the score-full.yaml file from the score schemas repo, we get:

```
$ go run cmd/score-helm/main.go run -f ../schema/samples/score-full.yaml
containers:
  container-one1:
    args:
      - hello
      - world
    command:
      - /bin/sh
      - -c
    env:
      - name: SOME_VAR
        value: some content here
    image:
      name: localhost:4000/repo/my-image:tag
    livenessProbe:
      path: /livez
      port: 8080
      type: http
    readinessProbe:
      httpHeaders:
        SOME_HEADER: some-value-here
      path: /readyz
      port: 80
      type: http
    resources:
      limits:
        cpu: "0.24"
        memory: 128M
      requests:
        cpu: 1000m
        memory: 10Gi
    volumeMounts:
      - mountPath: /mnt/something
        name: volume-name
        readOnly: false
        subPath: /sub/path
      - mountPath: /mnt/something-else
        name: volume-two
  container-two2:
    image:
      name: .
service:
  ports:
    - name: port-one
      port: 1000
      protocol: TCP
      targetPort: 10000
    - name: port-two2
      port: 8000
  type: ClusterIP
```

Which is what is expected.