### PR TITLE
init: update the default sample Score file generated

### DIFF
--- a/internal/command/generate_test.go
+++ b/internal/command/generate_test.go
@@ -93,25 +93,19 @@ func TestInitAndGenerate_with_sample(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "", stdout)
-	raw, err := os.ReadFile(filepath.Join(td, "values.yaml"))
-	assert.NoError(t, err)
-	assert.Equal(t, `containers:
-  main:
-    image:
-      name: stefanprodan/podinfo
-service:
-  ports:
-    - name: web
-      port: 8080
-`, string(raw))
 
-	// check that state was persisted
+	// verify the output file was created
+	_, err = os.Stat(filepath.Join(td, "values.yaml"))
+	assert.NoError(t, err)
+
+	// check that state was persisted with the new sample structure
 	sd, ok, err := state.LoadStateDirectory(td)
 	assert.NoError(t, err)
 	assert.True(t, ok)
-	assert.Equal(t, "score.yaml", *sd.State.Workloads["example"].File)
+	assert.Equal(t, "score.yaml", *sd.State.Workloads["hello-world"].File)
 	assert.Len(t, sd.State.Workloads, 1)
-	assert.Len(t, sd.State.Resources, 0)
+	// new sample declares 3 resources: postgres, dns, and route
+	assert.Len(t, sd.State.Resources, 3)
 }
 
 func TestInitAndGenerate_with_full_example(t *testing.T) {

--- a/internal/command/init.go
+++ b/internal/command/init.go
@@ -15,16 +15,13 @@
 package command
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 
 	"github.com/score-spec/score-go/framework"
-	scoretypes "github.com/score-spec/score-go/types"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 
 	"github.com/score-spec/score-helm/internal/state"
 )
@@ -32,6 +29,37 @@ import (
 const (
 	initCmdFileFlag         = "file"
 	initCmdFileNoSampleFlag = "no-sample"
+
+	DefaultScoreFileContent = `# Score provides a developer-centric and platform-agnostic
+# Workload specification to improve developer productivity and experience.
+# Score eliminates configuration management between local and remote environments.
+#
+# Get started with Score: https://docs.score.dev/docs/get-started/.
+---
+apiVersion: score.dev/v1b1
+metadata:
+  name: hello-world
+  annotations:
+    tags: "nodejs,http,website,javascript,postgres"
+containers:
+  hello-world:
+    image: scorespec/sample-score-app:latest
+    variables:
+      PORT: "3000"
+      MESSAGE: "Hello, World!"
+resources:
+  db:
+    type: postgres
+  dns:
+    type: dns
+  route:
+    type: route
+service:
+  ports:
+    www:
+      port: 8080
+      targetPort: 3000
+`
 )
 
 var initCmd = &cobra.Command{
@@ -74,32 +102,7 @@ var initCmd = &cobra.Command{
 				if !errors.Is(err, os.ErrNotExist) {
 					return fmt.Errorf("failed to check for existing Score file: %w", err)
 				}
-				workload := &scoretypes.Workload{
-					ApiVersion: "score.dev/v1b1",
-					Metadata: map[string]interface{}{
-						"name": "example",
-					},
-					Containers: map[string]scoretypes.Container{
-						"main": {
-							Image: "stefanprodan/podinfo",
-						},
-					},
-					Service: &scoretypes.WorkloadService{
-						Ports: map[string]scoretypes.ServicePort{
-							"web": {Port: 8080},
-						},
-					},
-				}
-				var rawScore bytes.Buffer
-				scoreEnc := yaml.NewEncoder(&rawScore)
-				scoreEnc.SetIndent(2)
-				if err := scoreEnc.Encode(workload); err != nil {
-					return fmt.Errorf("failed to encode Score file: %w", err)
-				}
-				if err := scoreEnc.Close(); err != nil {
-					return fmt.Errorf("failed to encode Score file: %w", err)
-				}
-				if err := os.WriteFile(initCmdScoreFile, rawScore.Bytes(), 0755); err != nil {
+				if err := os.WriteFile(initCmdScoreFile, []byte(DefaultScoreFileContent), 0755); err != nil {
 					return fmt.Errorf("failed to write Score file: %w", err)
 				}
 				slog.Info("Created initial Score file", "file", initCmdScoreFile)

--- a/internal/command/init_test.go
+++ b/internal/command/init_test.go
@@ -43,17 +43,8 @@ func TestInitNominal(t *testing.T) {
 
 	raw, err := os.ReadFile("score.yaml")
 	require.NoError(t, err)
-	assert.Equal(t, `apiVersion: score.dev/v1b1
-containers:
-  main:
-    image: stefanprodan/podinfo
-metadata:
-  name: example
-service:
-  ports:
-    web:
-      port: 8080
-`, string(raw))
+	assert.Contains(t, string(raw), "name: hello-world")
+	assert.Contains(t, string(raw), "scorespec/sample-score-app:latest")
 
 	stdout, stderr, err = executeAndResetCommand(context.Background(), rootCmd, []string{"generate", "score.yaml"})
 	assert.NoError(t, err)
@@ -65,7 +56,11 @@ service:
 	if assert.True(t, ok) {
 		assert.Equal(t, state.DefaultRelativeStateDirectory, sd.Path)
 		assert.Len(t, sd.State.Workloads, 1)
-		assert.Equal(t, map[framework.ResourceUid]framework.ScoreResourceState[state.ResourceExtras]{}, sd.State.Resources)
+		assert.Contains(t, sd.State.Workloads, "hello-world")
+		assert.Len(t, sd.State.Resources, 3)
+		assert.Contains(t, sd.State.Resources, framework.ResourceUid("postgres.default#hello-world.db"))
+		assert.Contains(t, sd.State.Resources, framework.ResourceUid("dns.default#hello-world.dns"))
+		assert.Contains(t, sd.State.Resources, framework.ResourceUid("route.default#hello-world.route"))
 		assert.Equal(t, map[string]interface{}{}, sd.State.SharedState)
 	}
 }


### PR DESCRIPTION
#### Description
The default `score.yaml` generated by `score-helm init` was using a basic `stefanprodan/podinfo` example. This PR replaces it with a more meaningful sample for consistency across all Score implementations.

#### What does this PR do?
Follow-up to score-spec/score-compose#476, score-spec/score-k8s#302, and score-spec/score-implementation-sample#103 as requested by @mathieu-benoit.

Updates the sample to use `scorespec/sample-score-app:latest` with postgres, dns, and route resources. Switched from struct-based YAML generation to a `DefaultScoreFileContent` raw string constant, which is simpler and supports comments.

Updated `TestInitNominal` and `TestInitAndGenerate_with_sample` accordingly.

#### Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
- [x] My change requires a change to the documentation.
- [x] I've signed off with an email address that matches the commit author.
